### PR TITLE
Fix win CI: pin to windows-2022 (Visual Studio 17 2022)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -31,7 +31,7 @@ jobs:
           pip install cookiecutter
 
       - name: Install dependencies (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           pip install cookiecutter
           choco install 7zip
@@ -45,7 +45,7 @@ jobs:
             project_slug="pr_test"
 
       - name: Generate project (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           cookiecutter . --no-input rbfx_sdk_install="dll" project_name="PR Test" project_slug="pr_test" editor=n
 
@@ -59,7 +59,7 @@ jobs:
           cmake --build pr_test/build
 
       - name: Configure and build (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
-          cmake -S pr_test -B pr_test/build -G "Visual Studio 17 2022" -A x64 -DBUILD_SHARED_LIBS=ON "-DCMAKE_PREFIX_PATH=../rbfx"
+          cmake -S pr_test -B pr_test/build -DBUILD_SHARED_LIBS=ON "-DCMAKE_PREFIX_PATH=../rbfx"
           cmake --build pr_test/build --config RelWithDebInfo

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,7 +27,7 @@ jobs:
           pip install cookiecutter
 
       - name: Install dependencies (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           pip install cookiecutter
           choco install 7zip
@@ -41,7 +41,7 @@ jobs:
             project_slug="weekly_test"
 
       - name: Generate project (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           cookiecutter . --no-input rbfx_sdk_install="dll" project_name="Weekly Test" project_slug="weekly_test" editor=n
 
@@ -55,7 +55,7 @@ jobs:
           cmake --build weekly_test/build
 
       - name: Configure and build (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: |
           cmake -S weekly_test -B weekly_test/build -DBUILD_SHARED_LIBS=ON "-DCMAKE_PREFIX_PATH=../rbfx"
           cmake --build weekly_test/build --config RelWithDebInfo

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -57,5 +57,5 @@ jobs:
       - name: Configure and build (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          cmake -S weekly_test -B weekly_test/build -G "Visual Studio 17 2022" -A x64 -DBUILD_SHARED_LIBS=ON "-DCMAKE_PREFIX_PATH=../rbfx"
+          cmake -S weekly_test -B weekly_test/build -DBUILD_SHARED_LIBS=ON "-DCMAKE_PREFIX_PATH=../rbfx"
           cmake --build weekly_test/build --config RelWithDebInfo


### PR DESCRIPTION
windows-latest was redirecting to a newer visual studio since june 2026.
This commit pins visual studio 17 2022.